### PR TITLE
Update schema type documentation: hook_graphql_compose_schema_type_alter() does not exist.

### DIFF
--- a/extending/schema_type.md
+++ b/extending/schema_type.md
@@ -295,7 +295,7 @@ If you're a savvy developer, you can override or modify a schema type by alterin
 /**
  * Implements hook_graphql_compose_field_type_alter().
  */
-function mymodule_graphql_compose_schema_type_alter(array &$entity_types) {
+function mymodule_graphql_compose_graphql_type_alter(array &$entity_types) {
   $entity_types['address']['class'] = 'Drupal\mymodule\MyAddressSchemaType';
 }
 ```


### PR DESCRIPTION
In the documentation, the hook `hook_graphql_compose_schema_type_alter()` is mentioned, which does not exists. This should be `hook_graphql_compose_graphql_type_alter()`.

https://drupal-graphql-compose.github.io/documentation/#/extending/schema_type?id=option-override-graphql-compose